### PR TITLE
Fix shader for Godot 4.0 GLES3 renderer

### DIFF
--- a/PaletteSwap.gdshader
+++ b/PaletteSwap.gdshader
@@ -1,6 +1,6 @@
 shader_type canvas_item;
 
-uniform sampler2D palette : filter_nearest;
+uniform sampler2D palette : filter_nearest, repeat_disable;
 uniform bool skip_first_row = true;
 uniform bool use_palette_alpha = false;
 uniform float fps = 6;


### PR DESCRIPTION
There is a strange bug with the shader when using Godot 4.0's GLES3 renderer which I believe has to do with the differences in how textures are filtered between Vulkan and GLES3. This pull request fixes that issue by changing the filtering settings on the palette texture.